### PR TITLE
Test File Listener ignores certain LinkKinds.  

### DIFF
--- a/src/main/java/no/priv/garshol/duke/matchers/TestFileListener.java
+++ b/src/main/java/no/priv/garshol/duke/matchers/TestFileListener.java
@@ -118,6 +118,11 @@ public class TestFileListener extends AbstractMatchListener {
       if (debug && !showmatches)
         PrintMatchListener.show(r1, r2, confidence, "\nINCORRECT",
                                 props, pretty);
+    } else {
+      unknown++; // we don't know if this one is right or not
+      if (debug && !showmatches)
+        PrintMatchListener.show(r1, r2, confidence, "\nUNKNOWN LINK TYPE",
+                                props, pretty);
     }
   }
   


### PR DESCRIPTION
Was having trouble getting the genetic algorithm to correctly identify links using a test file of all "+" matches (which implies anything not in the file is a "-").  This patch provides a default match of "unknown" if the link isn't explicitly SAME or DIFFERENT, allowing more accurate recall / f-factor calculations.
