### PR TITLE
Added "databases" package in the "klass" FQN

### DIFF
--- a/duke-core/src/main/java/no/priv/garshol/duke/ConfigLoader.java
+++ b/duke-core/src/main/java/no/priv/garshol/duke/ConfigLoader.java
@@ -195,7 +195,7 @@ public class ConfigLoader {
       } else if (localName.equals("database")) {
         String klass = attributes.getValue("class");
         if (klass == null)
-          klass = "no.priv.garshol.duke.LuceneDatabase"; // default
+          klass = "no.priv.garshol.duke.databases.LuceneDatabase"; // default
         database = (Database) instantiate(klass);
         currentobj = database;
       }


### PR DESCRIPTION
As soon you put the tag "database" without the "class" attribute, it try to instantiate `no.priv.garshol.duke.LuceneDatabase` which of course do not exits anymore since it was moved to `no.priv.garshol.duke.databases.LuceneDatabase`.

BTW : Thanks for your software !