### PR TITLE
This permits to have multiple columns

### DIFF
--- a/duke-core/src/main/java/no/priv/garshol/duke/datasources/CSVDataSource.java
+++ b/duke-core/src/main/java/no/priv/garshol/duke/datasources/CSVDataSource.java
@@ -134,8 +134,18 @@ public class CSVDataSource extends ColumnarDataSource {
 
       // index here is random 0-n. index[0] gives the column no in the CSV
       // file, while colname[0] gives the corresponding column name.
-      index = new int[columns.size()];
-      column = new Column[columns.size()];
+
+      int totalColumnSize=0;
+      final Set<String> strings = columns.keySet();
+      for(String key:strings){
+        Collection<Column> collection=columns.get(key);
+        if(collection!=null){
+          totalColumnSize+=collection.size();
+        }
+      }
+
+      index = new int[totalColumnSize];
+      column = new Column[totalColumnSize];
 
       // skip the required number of lines before getting to the data
       for (int ix = 0; ix < skiplines; ix++)


### PR DESCRIPTION
As you can see bellow, the input field `TE_NOM` is indexed as `TE_NOM` and `NomSoundex` in the database.
With the original code, there is a column index mismatch and the program fails.
The updated code take into account a one to many relation. (One source column binds to many indexed columns)

This is an important feature since it permits to to more granular rules and advanced blocking.

````
[...]
 <property>
            <name>TE_NOM</name>
            <comparator>be.etnic.comparator.PersonNameComparator</comparator>
            <low>0.1</low>
            <high>0.50</high>
        </property>

        <property>
            <name>TE_PRENOM</name>
            <comparator>be.etnic.comparator.PersonNameComparator</comparator>
            <low>0.1</low>
            <high>0.60</high>
        </property>
<property>
            <name>NomSoundex</name>
            <comparator>no.priv.garshol.duke.comparators.MetaphoneComparator</comparator>
            <low>0.1</low>
            <high>0.7</high>
        </property>

        <property>
            <name>PrenomSoundex</name>
            <comparator>no.priv.garshol.duke.comparators.MetaphoneComparator</comparator>
            <low>0.1</low>
            <high>0.8</high>
        </property>
        [...]

        <column name="TE_NOM" cleaner="no.priv.garshol.duke.cleaners.LowerCaseNormalizeCleaner"/>
        <column property="NomSoundex" name="TE_NOM" cleaner="no.priv.garshol.duke.cleaners.LowerCaseNormalizeCleaner"/>
        <column name="TE_PRENOM" cleaner="no.priv.garshol.duke.cleaners.LowerCaseNormalizeCleaner"/>
        <column property="PrenomSoundex" name="TE_PRENOM" cleaner="no.priv.garshol.duke.cleaners.LowerCaseNormalizeCleaner"/>
````