### PR TITLE
Minimum code revision to use Lucene 5.

### DIFF
--- a/duke-lucene/pom.xml
+++ b/duke-lucene/pom.xml
@@ -1,50 +1,53 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>no.priv.garshol.duke</groupId>
-        <artifactId>duke</artifactId>
-        <version>1.3-SNAPSHOT</version>
-        <relativePath>../</relativePath>
-    </parent>
-    <artifactId>duke-lucene</artifactId>
-    <packaging>jar</packaging>
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>no.priv.garshol.duke</groupId>
+		<artifactId>duke</artifactId>
+		<version>1.3-SNAPSHOT</version>
+		<relativePath>../</relativePath>
+	</parent>
+	<artifactId>duke-lucene</artifactId>
+	<packaging>jar</packaging>
 
-    <dependencies>
+	<properties>
+		<lucene.version>5.2.1</lucene.version>
+	</properties>
 
-        <dependency>
-            <groupId>no.priv.garshol.duke</groupId>
-            <artifactId>duke-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>no.priv.garshol.duke</groupId>
-            <artifactId>duke-core</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
+	<dependencies>
 
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-core</artifactId>
-            <version>4.0.0</version>
-        </dependency>
+		<dependency>
+			<groupId>no.priv.garshol.duke</groupId>
+			<artifactId>duke-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>no.priv.garshol.duke</groupId>
+			<artifactId>duke-core</artifactId>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
 
-        <!-- necessary to get KeywordAnalyzer and StandardAnalyzer -->
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-analyzers-common</artifactId>
-            <version>4.0.0</version>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-core</artifactId>
+			<version>${lucene.version}</version>
+		</dependency>
 
-        <!-- necessary for spatial searches
-             NOTE: the code is written so that Duke will work without it,
-                   as long as you don't use spatial searches -->
-        <dependency>
-            <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-spatial</artifactId>
-            <version>4.0.0</version>
-        </dependency>
+		<!-- necessary to get KeywordAnalyzer and StandardAnalyzer -->
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-analyzers-common</artifactId>
+			<version>${lucene.version}</version>
+		</dependency>
 
-    </dependencies>
+		<!-- necessary for spatial searches NOTE: the code is written so that Duke 
+			will work without it, as long as you don't use spatial searches -->
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-spatial</artifactId>
+			<version>${lucene.version}</version>
+		</dependency>
+
+	</dependencies>
 
 </project>

--- a/duke-lucene/src/main/java/no/priv/garshol/duke/databases/LuceneDatabase.java
+++ b/duke-lucene/src/main/java/no/priv/garshol/duke/databases/LuceneDatabase.java
@@ -1,22 +1,12 @@
 
 package no.priv.garshol.duke.databases;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.file.FileSystems;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import no.priv.garshol.duke.Comparator;
-import no.priv.garshol.duke.Configuration;
-import no.priv.garshol.duke.Database;
-import no.priv.garshol.duke.DukeConfigException;
-import no.priv.garshol.duke.DukeException;
-import no.priv.garshol.duke.Property;
-import no.priv.garshol.duke.Record;
-import no.priv.garshol.duke.comparators.GeopositionComparator;
-import no.priv.garshol.duke.utils.Utils;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
@@ -45,7 +35,16 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.store.RAMDirectory;
-import org.apache.lucene.util.Version;
+
+import no.priv.garshol.duke.Comparator;
+import no.priv.garshol.duke.Configuration;
+import no.priv.garshol.duke.Database;
+import no.priv.garshol.duke.DukeConfigException;
+import no.priv.garshol.duke.DukeException;
+import no.priv.garshol.duke.Property;
+import no.priv.garshol.duke.Record;
+import no.priv.garshol.duke.comparators.GeopositionComparator;
+import no.priv.garshol.duke.utils.Utils;
 
 /**
  * Represents the Lucene index, and implements record linkage services
@@ -74,7 +73,7 @@ public class LuceneDatabase implements Database {
   private GeoProperty geoprop;
 
   public LuceneDatabase() {
-    this.analyzer = new StandardAnalyzer(Version.LUCENE_CURRENT);
+    this.analyzer = new StandardAnalyzer();
     this.maintracker = new EstimateResultTracker();
     this.max_search_hits = 1000000;
     this.fuzzy_search = true; // on by default
@@ -329,13 +328,13 @@ public class LuceneDatabase implements Database {
           // as per http://wiki.apache.org/lucene-java/ImproveSearchingSpeed
           // we use NIOFSDirectory, provided we're not on Windows
           if (Utils.isWindowsOS())
-            directory = FSDirectory.open(new File(path));
+            directory = FSDirectory.open(FileSystems.getDefault().getPath(path));
           else
-            directory = NIOFSDirectory.open(new File(path));
+            directory = NIOFSDirectory.open(FileSystems.getDefault().getPath(path));
         }
 
         IndexWriterConfig cfg =
-          new IndexWriterConfig(Version.LUCENE_CURRENT, analyzer);
+          new IndexWriterConfig(analyzer);
         cfg.setOpenMode(overwrite ? IndexWriterConfig.OpenMode.CREATE :
                                     IndexWriterConfig.OpenMode.APPEND);
         iwriter = new IndexWriter(directory, cfg);
@@ -371,8 +370,9 @@ public class LuceneDatabase implements Database {
     if (value != null) {
       Analyzer analyzer = new KeywordAnalyzer();
 
+      TokenStream tokenStream = null;
       try {
-        TokenStream tokenStream =
+        tokenStream =
           analyzer.tokenStream(fieldName, new StringReader(value));
         tokenStream.reset();
         CharTermAttribute attr =
@@ -386,6 +386,16 @@ public class LuceneDatabase implements Database {
       } catch (IOException e) {
         throw new DukeException("Error parsing input string '" + value + "' " +
                                 "in field " + fieldName);
+      }
+      finally {
+          if (null != tokenStream) {
+              try {
+                tokenStream.close();
+              }
+              catch (IOException e) {
+                  throw new DukeException("Error closing token stream");
+              }
+          }
       }
     }
 
@@ -402,8 +412,9 @@ public class LuceneDatabase implements Database {
     if (value.length() == 0)
       return;
 
+    TokenStream tokenStream = null;
     try {
-      TokenStream tokenStream =
+      tokenStream =
         analyzer.tokenStream(fieldName, new StringReader(value));
       tokenStream.reset();
       CharTermAttribute attr =
@@ -426,6 +437,16 @@ public class LuceneDatabase implements Database {
     } catch (IOException e) {
       throw new DukeException("Error parsing input string '"+value+"' "+
                               "in field " + fieldName);
+    }
+    finally {
+        if (null != tokenStream) {
+            try {
+              tokenStream.close();
+            }
+            catch (IOException e) {
+                throw new DukeException("Error closing token stream");
+            }
+        }
     }
   }
 


### PR DESCRIPTION
* Maven dependency to Lucene libraries set to 5.x.x version
* Explicit version parameters removed according to new function
signatures
* All token streams explicitly closed in finally blocks